### PR TITLE
audit(04): chat UI & streaming findings + onChatStatus console.log auto-fix

### DIFF
--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -30,7 +30,7 @@ Update your row when you begin (`in_progress`) and when you finish (`done`). Do 
 | 01 | [01-gateway-protocol.md](01-gateway-protocol.md) | `src/lib/openclaw/` + pinned-ws module | todo | — | — | — |
 | 02 | [02-auth-pairing.md](02-auth-pairing.md) | device-identity, ConnectionContext, useConnection, auth-callback | todo | — | — | — |
 | 03 | [03-server-profiles.md](03-server-profiles.md) | useServerConfig, ServerProfileSync, AddServerSheet, pinning UI | todo | — | — | — |
-| 04 | [04-chat-streaming.md](04-chat-streaming.md) | chat components, useChat, chatCache, messageBlocks, streamReveal | todo | — | — | — |
+| 04 | [04-chat-streaming.md](04-chat-streaming.md) | chat components, useChat, chatCache, messageBlocks, streamReveal | done | [findings](findings/04-chat-streaming-findings.md) | C:0/H:0/M:3/L:3/N:2 | 2026-05-09 |
 | 05 | [05-input-slash-commands.md](05-input-slash-commands.md) | InputBar, SlashCommandPalette, useCommands, useDraft | todo | — | — | — |
 | 06 | [06-sessions-sidebar.md](06-sessions-sidebar.md) | SessionSidebar, useSessions, gesture drawer | todo | — | — | — |
 | 07 | [07-agents-models-skills.md](07-agents-models-skills.md) | useAgents, useModels, useAgentFiles, modelProvider | todo | — | — | — |

--- a/docs/audits/findings/04-chat-streaming-findings.md
+++ b/docs/audits/findings/04-chat-streaming-findings.md
@@ -1,0 +1,47 @@
+# Chat UI & Streaming Findings
+
+Date: 2026-05-09
+Agent: claude-sonnet-4-5
+Status: done
+
+## Summary
+
+The chat streaming subsystem is well-implemented with solid stream-isolation discipline, correct generation-counter guards, an encrypted disk cache, and thoughtful performance optimisations (RAF-coalesced chunks, segmented markdown rendering, React.memo throughout). The main concerns are size — three files far exceed the 300-line guideline and are split candidates — plus a missing crypto unit test and a missing `accessibilityLiveRegion` on streaming content.
+
+## Severity Counts
+
+- critical: 0
+- high: 0
+- med: 3
+- low: 3
+- nit: 2
+
+## Findings
+
+| ID | Sev | File:Line | Summary | Recommendation | Status |
+|----|-----|-----------|---------|----------------|--------|
+| chat-001 | med | src/hooks/useChat.ts:1 | `useChat.ts` is 1865 lines — 6× the ~300-line guideline | Propose split: extract `useChatEventSubscriptions` (the large `useEffect` subscribing to 11 events, ~750 lines), `useChatSend` (sendMessage + abortResponse + retryMessage, ~350 lines), leaving the main hook as a thin compositor. The pure helper functions at the top (closePendingPart, upsertThinkingPart, etc.) can move to a co-located `chatHelpers.ts`. | proposed |
+| chat-002 | med | src/components/chat/MessageBubble.tsx:1 | `MessageBubble.tsx` is 1225 lines — 4× the guideline | The file already defines 6 sub-components (MessageBlocks, MessageBody, MessageParts, StreamingTextPart, MessageBubbleActions, MessageBubble). Extract each into its own file under `src/components/chat/`. The link/paragraph/fence rule factories (~100 lines) can move to `src/utils/markdownRules.ts`. | proposed |
+| chat-003 | med | src/components/chat/MessageList.tsx:1 | `MessageList.tsx` is 1097 lines — 3.7× the guideline | Extract session-transition animation logic (~120 lines) into `useMessageListTransition.ts`, scroll management (~120 lines) into `useMessageListScroll.ts`, leaving MessageList as a thinner render coordinator. | proposed |
+| chat-004 | low | src/lib/chatCache/crypto.ts:1 | `sealBytes`/`openBytes` (AES-256-GCM) have no unit tests | Add `src/lib/chatCache/__tests__/crypto.test.ts` covering: (1) seal then open round-trip, (2) openBytes returns null for a truncated packet, (3) openBytes returns null when no key exists, (4) seal produces a fresh IV each call (ciphertexts differ). | proposed |
+| chat-005 | low | src/hooks/useChat.ts:1415–1423 | `onChatStatus` handler has no production logic; it only performs a dev-mode `console.log` of the full gateway payload | Remove the `console.log` call (auto-fixable per rules). The subscription itself can remain (the handler becomes a no-op, harmless). | fixed |
+| chat-006 | low | src/hooks/useMediaCacheReplay.ts:26 | `JSON.parse(raw) as boolean` uses a TypeScript cast without runtime type narrowing; a corrupted AsyncStorage value will silently set `enabled` to a non-boolean | Change to `const parsed = JSON.parse(raw); if (typeof parsed === 'boolean') setEnabledState(parsed);` | proposed |
+| chat-007 | nit | src/components/chat/ThinkingNode.tsx:1 | ThinkingNode.tsx is 348 lines — slightly above the ~300-line guideline | Minor: extract the shimmer rendering (MaskedView + LinearGradient + RNAnimated loop, ~60 lines) into a co-located `ThinkingShimmer.tsx`. | proposed |
+| chat-008 | nit | src/components/chat/StreamingText.tsx:49 | `StreamingText` component (the typing-dots pill) has no `accessibilityLiveRegion` — screen readers will not announce when streaming begins or ends | Add `accessibilityLiveRegion="polite"` and `accessibilityLabel` to the container `View` of `StreamingText`. For the inline streaming bubble in `MessageBody`/`StreamingTextPart`, add `accessibilityLiveRegion="polite"` to the wrapper View so VoiceOver/TalkBack can announce updates. | proposed |
+
+## Auto-Fixes Applied
+
+- chat-005 (low): removed the non-critical `console.log('[useChat:chatStatus]', payload)` dev-only log inside `onChatStatus` in `src/hooks/useChat.ts`. The handler is now a generation-guard no-op, which is correct — `chatStatus` events currently have no production consumer.
+
+## Open Questions for Human
+
+- **chat-001 split**: The 11-event `useEffect` in `useChat.ts` captures many closure variables (`updateSessionMessages`, `flushSessionToDisk`, `setActivity`, etc.). Any split must pass these through props/args rather than closure capture to avoid stale-closure bugs. The human should review the proposed split boundary before execution.
+- **chat-006**: Is there any migration path if existing AsyncStorage values are malformed (e.g., the key stores a string `"1"` from an older build)? The proposed fix silently ignores non-boolean values, leaving the default (`true`). Confirm this is acceptable.
+- **chat-004 crypto tests**: The `sealBytes`/`openBytes` functions depend on `expo-secure-store` and `expo-crypto` which require native mocking in Jest. Confirm that the project's Jest setup includes the necessary mocks (check `jest.setup.ts` / `jest.config.ts`) before adding the test file.
+
+## Test Impact
+
+- `npm test --selectProjects components`: 9 snapshot failures in `MessageBubble.test.tsx` and `ThinkingNode.test.tsx` — **pre-existing on base branch** (time-format timezone drift in snapshots, unrelated to this audit). 115 tests pass.
+- `npm test --selectProjects logic`: 5 failures in `validateBlob.test.ts` — **pre-existing on base branch** (tests expect schema version 3 but implementation has advanced to version 4, a stale snapshot issue). 779 tests pass.
+- The auto-fix applied (chat-005: removed `console.log` in `onChatStatus`) does not affect any test outcomes — the handler had no test coverage.
+- No new tests added (test additions are proposed-only per `_RULES.md`)

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -1412,12 +1412,9 @@ export function useChat(): UseChatResult {
       }
     };
 
-    const onChatStatus = (payload: unknown): void => {
+    const onChatStatus = (_payload: unknown): void => {
       if (connectGenRef.current !== genAtSubscribe) {
         return;
-      }
-      if (__DEV__) {
-        console.log('[useChat:chatStatus]', payload);
       }
     };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Audit Plan 04 — Chat UI & Streaming

Runs audit plan `docs/audits/04-chat-streaming.md` against:
- `src/components/chat/**`
- `src/hooks/useChat.ts`, `useChatDiskHydration.ts`, `useStreamReveal.ts`, `useMediaCacheReplay.ts`
- `src/lib/messageBlocks.ts`, `src/lib/messageMerge.ts`, `src/lib/chatCache/**`

### Summary

The chat streaming subsystem is well-implemented. Stream-isolation discipline (`connectGenRef` generation guards, per-session key routing), the encrypted disk cache (AES-256-GCM via `@noble/ciphers`), and per-frame performance optimisations (RAF-coalesced chunks, segmented markdown rendering, `React.memo` throughout) are all in good shape. The main concerns are file size and a handful of low-severity items.

### Severity Counts

| Sev | Count |
|-----|-------|
| critical | 0 |
| high | 0 |
| med | 3 |
| low | 3 |
| nit | 2 |

### Key Findings

| ID | Sev | Summary |
|----|-----|---------|
| chat-001 | med | `useChat.ts` is **1865 lines** (6× the ~300-line guideline) — split candidate |
| chat-002 | med | `MessageBubble.tsx` is **1225 lines** (4×) — split candidate |
| chat-003 | med | `MessageList.tsx` is **1097 lines** (3.7×) — split candidate |
| chat-004 | low | `chatCache/crypto.ts` (`sealBytes`/`openBytes`) has no unit tests |
| chat-005 | low | `onChatStatus` only had a `__DEV__` console.log — **auto-fixed** |
| chat-006 | low | `useMediaCacheReplay`: `JSON.parse(raw) as boolean` lacks runtime type guard |
| chat-007 | nit | `ThinkingNode.tsx` at 348 lines — minor overage |
| chat-008 | nit | `StreamingText` lacks `accessibilityLiveRegion` for screen readers |

### Auto-Fix Applied

**chat-005** — removed non-critical `console.log('[useChat:chatStatus]', payload)` from `onChatStatus` in `useChat.ts`. The handler had no production logic; only a dev-only log of the raw gateway payload. The subscription itself is preserved (no-op handler is harmless).

### Tests

- `--selectProjects logic`: **779 pass**, 5 pre-existing failures in `validateBlob.test.ts` (schema version mismatch, unrelated to this audit).
- `--selectProjects components`: **115 pass**, 9 pre-existing snapshot failures (timezone drift in time-format snapshots, unrelated to this audit).
- The auto-fix has no effect on any test.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d80c7a87-c0d8-4782-9dfd-a50ba3f41bea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d80c7a87-c0d8-4782-9dfd-a50ba3f41bea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

