### PR TITLE
audit(17): OTA updates findings + ota-002 auto-fix

### DIFF
--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -43,7 +43,7 @@ Update your row when you begin (`in_progress`) and when you finish (`done`). Do 
 | 14 | [14-account-supabase.md](14-account-supabase.md) | src/lib/supabase/, AccountContext, account UI | todo | — | — | — |
 | 15 | [15-achievements-badges.md](15-achievements-badges.md) | badges components, achievements screen | todo | — | — | — |
 | 16 | [16-demo-mode.md](16-demo-mode.md) | src/lib/demo/, DemoModeBanner, useChat demo branch | todo | — | — | — |
-| 17 | [17-ota-updates.md](17-ota-updates.md) | useOTAUpdate, UpdateNudgeBanner, certs/, app.json updates | todo | — | — | — |
+| 17 | [17-ota-updates.md](17-ota-updates.md) | useOTAUpdate, UpdateNudgeBanner, certs/, app.json updates | done | [findings](findings/17-ota-updates-findings.md) | C:0 H:0 M:2 L:2 N:3 | 2026-05-09 |
 | 18 | [18-feedback-worker.md](18-feedback-worker.md) | infra/feedback-worker/, src/lib/feedback/, FeedbackSheet | todo | — | — | — |
 | 19 | [19-conventions.md](19-conventions.md) | ConventionInstallContext, installConventions, conventions UI | todo | — | — | — |
 | 20 | [20-theme-i18n-appearance.md](20-theme-i18n-appearance.md) | ThemeContext, LanguageContext, i18n/, appearance settings | todo | — | — | — |

--- a/docs/audits/findings/17-ota-updates-findings.md
+++ b/docs/audits/findings/17-ota-updates-findings.md
@@ -1,0 +1,48 @@
+# OTA Updates Findings
+
+Date: 2026-05-09
+Agent: claude-sonnet-4-6
+Status: done
+
+## Summary
+
+The OTA update subsystem is well-structured and security-conscious: the private key was never committed, code-signing is correctly configured, and the two hooks (`useOTAUpdate`, `useGatewayUpdateNudge`) maintain clean separation of concerns. The main issues are a redundant dual-check on startup, a misleading banner message that directs users to Settings when the update is already downloading in the background, and a personal local path leaked in `eas.json`.
+
+## Severity Counts
+
+- critical: 0
+- high: 0
+- med: 2
+- low: 2
+- nit: 3
+
+## Findings
+
+| ID | Sev | File:Line | Summary | Recommendation | Status |
+|----|-----|-----------|---------|----------------|--------|
+| ota-CERT | pass | certs/ | `certs/private-key.pem` was never committed to git history; `.gitignore` correctly excludes it; `certificate.pem` contains only the public cert | No action required | closed |
+| ota-001 | med | app.json:12 / src/hooks/useOTAUpdate.ts:31 | `checkAutomatically: "ON_LOAD"` in `app.json` triggers a native background check on every launch; `useOTAUpdate` then independently calls `checkForUpdateAsync()` + `fetchUpdateAsync()` in the same launch cycle. Two concurrent `fetchUpdateAsync()` calls waste bandwidth and may race on staging the downloaded bundle. The hook is still needed for `critical` flag detection, but the duplication is unnecessary for the non-critical path. | Set `"checkAutomatically": "NEVER"` in `app.json` and rely entirely on `useOTAUpdate` (and `useGatewayUpdateNudge`) to drive all update checks. This removes the race and consolidates logic in one place. Requires `eas.json` and native build review — proposed, not auto-fixed. | proposed |
+| ota-002 | nit | src/hooks/useGatewayUpdateNudge.ts:73 | `client` (a `useRef` return value) was included in the `useEffect` dependency array. `useRef` objects are stable references that never change identity; the linter's `react-hooks/exhaustive-deps` rule treats them as stable and does not require them in deps. Its presence misleads readers into thinking the effect re-runs when the client changes. | Remove `client` from the dep array. **Auto-fixed.** | fixed |
+| ota-003 | med | eas.json (read-only):33 | `submit.production.ios.ascApiKeyPath` contains a hardcoded local path: `/Users/kirby/Downloads/Code Projects/clawboy-expo/AuthKey_X67X7737ZG.p8`. This (a) causes `eas submit` to fail on every machine except the original author's, (b) leaks a personal filesystem path in a public repo, and (c) exposes the App Store Connect key ID (`X67X7737ZG`) and issuer ID. | Replace the hardcoded path with an env-var reference (e.g. `$ASC_API_KEY_PATH`) or remove the `ascApiKeyPath` field and pass it via `--api-key-path` at submit time. **`eas.json` is out of scope for auto-fix — flag only.** | proposed |
+| ota-004 | low | src/i18n/locales/en/common.json (via UpdateNudgeBanner.tsx:35) | The banner message `"A required update is available. Go to Settings → About to check for updates."` is inaccurate. `useGatewayUpdateNudge` already silently fetches the update in the background. Directing the user to Settings is wrong — the correct instruction is to restart the app once the download completes. | Change message to something like `"A newer version of ClawBoy is ready. Restart the app to apply the update."` and align the `zh-CN` locale. Changing i18n string values is a proposed fix (not auto-applied). | proposed |
+| ota-005 | low | src/components/chat/UpdateNudgeBanner.tsx:38 | Dismiss button has `accessibilityLabel` but no `accessibilityHint`. For screen-reader users who are not familiar with the banner, a hint explaining what "dismiss" does (e.g. `"Hides this update notice until the next version is available"`) improves usability. | Add `accessibilityHint={t('chat.updateBanner.dismissHint')}` and a corresponding i18n key. Adding i18n keys is a proposed fix. | proposed |
+| ota-006 | nit | src/components/chat/UpdateNudgeBanner.tsx:28 | `overflow: 'hidden'` is included inside `useAnimatedStyle`. It is a static (non-animated) value and does not need to run in a Reanimated worklet. Static styles inside `useAnimatedStyle` are evaluated on the JS thread on every animation frame, adding minimal but unnecessary overhead. | Move `overflow: 'hidden'` to a static `StyleSheet` entry and spread it alongside the animated style. Changing animation code requires human review — proposed. | proposed |
+| ota-007 | nit | src/hooks/__tests__/ | No unit tests exist for `useOTAUpdate` or `useGatewayUpdateNudge`. These hooks are difficult to test (require mocking `expo-updates` and the connection context), but the `isBelowVersion` helper in `useGatewayUpdateNudge` is a pure function with no dependencies and is fully testable. | Extract `isBelowVersion` to a shared utility and add unit tests covering edge cases (pre-release suffixes, missing patch segment, equal versions). Test additions are a proposed fix. | proposed |
+| ota-008 | nit | scripts/generate-update-cert.sh:30 | Script uses RSA-2048. This meets the stated minimum (≥ 2048-bit RSA) and matches the `alg: "rsa-v1_5-sha256"` configured in `app.json`. Ed25519 would be preferable for new projects but `expo-updates` code signing currently only supports `rsa-v1_5-sha256`, so RSA-2048 is the correct choice. No action needed. | No action required; document as intentional in the script comment if desired. | closed |
+
+## Auto-Fixes Applied
+
+- **ota-002** (nit): removed `client` (a stable `useRef` object) from the `useEffect` dependency array in `src/hooks/useGatewayUpdateNudge.ts` line 73. No behavior change — the effect is gated on `connectionState.status` which is sufficient; `client.current` is read inside the effect body at the moment the effect fires, not as a reactive dependency.
+
+## Open Questions for Human
+
+- **ota-001**: Deciding between `checkAutomatically: "NEVER"` (hook-driven only) and keeping `ON_LOAD` (belt-and-suspenders) is a product call. `ON_LOAD` provides a safety net if the hook somehow doesn't run (e.g. render is aborted), but the current combination can race. The audit recommends removing `ON_LOAD` and trusting the hook.
+- **ota-003**: The `eas.json` `ascApiKeyPath` personal path must be cleaned up before any other developer (or CI) can run `eas submit`. This should be an immediate fix but is outside this audit's auto-fix scope.
+- **ota-004**: The banner message update should be coordinated with whoever owns the copy/localization workflow, since both `en` and `zh-CN` locales need updating.
+
+## Test Impact
+
+- `npm test` run after applying ota-002 auto-fix.
+- Result: **3 suites failed, 57 passed | 14 tests failed, 894 passed | 9 snapshots failed, 40 passed** — identical result confirmed against the unmodified base branch (same failures pre-exist; stash-verified).
+- All pre-existing snapshot failures are in `MessageBubble` tests and are due to timezone-dependent timestamp rendering (`4:00 AM` vs `12:00 PM`), unrelated to OTA changes.
+- No OTA-specific test files exist; my auto-fix introduced no new failures.

--- a/src/hooks/useGatewayUpdateNudge.ts
+++ b/src/hooks/useGatewayUpdateNudge.ts
@@ -70,7 +70,7 @@ export function useGatewayUpdateNudge(): {
         }
       })();
     }
-  }, [connectionState.status, client]);
+  }, [connectionState.status]);
 
   const dismissNudge = useCallback(() => setNudgeVisible(false), []);
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Audit Plan 17 — OTA Updates

Runs the audit defined in `docs/audits/17-ota-updates.md`.

### What's in this PR

| File | Change |
|------|--------|
| `docs/audits/findings/17-ota-updates-findings.md` | New findings document (8 findings) |
| `src/hooks/useGatewayUpdateNudge.ts` | ota-002 auto-fix: removed stable `client` ref from `useEffect` dep array |
| `docs/audits/README.md` | Flipped row 17 from `todo` → `done` |

### Findings Summary

| ID | Sev | Summary |
|----|-----|---------|
| ota-CERT | pass | `certs/private-key.pem` was never committed to git; signing config is correct |
| ota-001 | med | Duplicate OTA check on startup: `checkAutomatically: "ON_LOAD"` races with `useOTAUpdate` hook |
| ota-002 | nit | Stable `client` ref unnecessarily in `useEffect` dep array — **auto-fixed** |
| ota-003 | med | `eas.json` `ascApiKeyPath` contains a personal machine path (flag only — file is read-only) |
| ota-004 | low | Banner message says "Go to Settings → About" but the update is already downloading in the background |
| ota-005 | low | `UpdateNudgeBanner` dismiss button missing `accessibilityHint` |
| ota-006 | nit | `overflow: 'hidden'` in `useAnimatedStyle` should be a static style |
| ota-007 | nit | No unit tests for OTA hooks; `isBelowVersion` is an untested pure function |

### Test Impact

Pre-existing failures (14 tests, 9 snapshots) in `MessageBubble` tests due to timezone-sensitive timestamps — confirmed identical before and after the auto-fix. My change introduces no new failures.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d77b98e6-4dd3-4408-b8e4-dbfc163f3f6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d77b98e6-4dd3-4408-b8e4-dbfc163f3f6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

