### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+ClawBoy is an Expo SDK 55 (React Native) iOS chat client for OpenClaw. Package manager is **npm** (`.npmrc` sets `legacy-peer-deps=true`). No linter is configured — TypeScript strict mode (`tsconfig.json`) is the code quality gate.
+
+### Running the app
+
+- **Web mode:** `npx expo start --web --port 8081` — requires `react-dom` and `react-native-web` (install with `npx expo install react-dom react-native-web` if missing). Bundling takes ~18s on first load.
+- **Native mode:** requires iOS Simulator or physical device (`npx expo run:ios`). Not available in Cloud Agent VMs.
+- The app needs an external OpenClaw gateway (`wss://`) + auth token to function beyond the onboarding screen. Without a real gateway, you can verify the onboarding flow, UI rendering, and error handling.
+
+### Running tests
+
+```bash
+npm test                  # pretest (version/changelog sync checks) + Jest (logic + components)
+npm run test:logic        # Pure TS logic tests only (fast, no native deps)
+npm run test:components   # Component rendering tests (jest-expo/ios preset)
+```
+
+**Snapshot timezone caveat:** Some component snapshot tests (`MessageBubble.test.tsx`, `SessionRow.test.tsx`) compare formatted timestamps. They were recorded in a US timezone. In UTC environments (Cloud VMs), these produce harmless snapshot mismatches (e.g., "4:00 AM" vs "12:00 PM"). Update snapshots with `npm test -- -u` only if your code changes don't affect timestamp logic.
+
+### Type checking
+
+```bash
+npx tsc --noEmit
+```
+
+### Key architecture notes for making changes
+
+- See `README.md` and `.cursorrules` for full architecture details.
+- Domain-specific hooks in `src/hooks/`, protocol layer in `src/lib/openclaw/`.
+- WebSocket client instance lives in a `useRef`, never in state/context.
+- All mocks for tests are in `src/__mocks__/` — two Jest projects (logic + components) use different module resolution. Check `jest.config.js` for the mapper tables.
+- The `modules/expo-pinned-websocket/` local module is linked via `file:./modules/expo-pinned-websocket` in `package.json`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents working on this codebase.

## What's included

- Project overview (Expo SDK 55, npm, no linter, TS strict mode)
- How to run the app in web mode (including the `react-dom`/`react-native-web` dependency note)
- How to run tests and the snapshot timezone caveat
- Type checking command
- Key architecture notes for making changes

## Demo

[clawboy_onboarding_demo.mp4](https://cursor.com/agents/bc-74e685d4-c89f-443c-bc96-7a08222adc2c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclawboy_onboarding_demo.mp4)

App successfully loads in web mode and the onboarding flow (gateway URL → auth token → connection attempt → error handling) works end-to-end.

[ClawBoy onboarding screen](https://cursor.com/agents/bc-74e685d4-c89f-443c-bc96-7a08222adc2c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_onboarding_screen.webp)
[Auth token input screen](https://cursor.com/agents/bc-74e685d4-c89f-443c-bc96-7a08222adc2c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_auth_token_screen.webp)
[Connection error handling](https://cursor.com/agents/bc-74e685d4-c89f-443c-bc96-7a08222adc2c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_connection_error.webp)

## Environment verification

- ✅ `npm install` — 967 packages installed
- ✅ `npm test` — 87/89 suites pass, 1282/1291 tests pass (9 snapshot timezone mismatches in UTC env)
- ✅ `npx tsc --noEmit` — clean
- ✅ `npx expo start --web` — web bundle compiles (4558 modules), app loads at localhost:8081

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74e685d4-c89f-443c-bc96-7a08222adc2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74e685d4-c89f-443c-bc96-7a08222adc2c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

