### PR TITLE
Opt-in iOS Voice Control input experiments (paste wrapper + layout)

### DIFF
--- a/src/components/input/InputBarCard.tsx
+++ b/src/components/input/InputBarCard.tsx
@@ -17,6 +17,7 @@ import { useThemeContext } from '@/contexts/ThemeContext';
 import { useTokens } from '@/hooks/useTokens';
 import type { TokenSet } from '@/hooks/useTokens';
 import { BorderRadius } from '@/constants/theme';
+import { IOS_INPUT_VOICE_CONTROL_EXPERIMENTS } from '@/constants/voiceControlInputExperiments';
 import { useTranslation } from 'react-i18next';
 
 import { InputBarActionBar } from './InputBarActionBar';
@@ -32,6 +33,9 @@ import type { InputAttachment } from './types';
 // watchdogs (8badf00d). Real devices don't exhibit this. We therefore only mount
 // the paste wrapper on real iOS hardware.
 const ENABLE_PASTE_WRAPPER = Platform.OS === 'ios' && Device.isDevice;
+
+/** Paste wrapper + mirror height — unless Voice Control experiments opt out (see `voiceControlInputExperiments.ts`). */
+const USE_IOS_PASTE_WRAPPER = ENABLE_PASTE_WRAPPER && !IOS_INPUT_VOICE_CONTROL_EXPERIMENTS;
 
 interface InputBarCardProps {
   /** Initial text for the uncontrolled TextInput. Changes here are ignored
@@ -153,6 +157,7 @@ export function InputBarCard({
   const lineHeight = Math.round(tokens.fs.base * 1.35);
 
   const [measuredHeight, setMeasuredHeight] = useState(minInputHeight);
+  const useMirrorHeight = !IOS_INPUT_VOICE_CONTROL_EXPERIMENTS;
 
   const placeholder = isThinking
     ? t('input.placeholder.thinking')
@@ -180,8 +185,10 @@ export function InputBarCard({
         {
           color: colors.foreground,
           lineHeight,
-          height: measuredHeight,
           maxHeight: maxInputHeight,
+          ...(useMirrorHeight
+            ? { height: measuredHeight }
+            : { minHeight: minInputHeight }),
         },
       ]}
       textAlignVertical="top"
@@ -215,32 +222,34 @@ export function InputBarCard({
 
         <Pressable onPress={() => inputRef.current?.focus()} style={styles.textTap}>
           <View style={styles.textWrap}>
-            {/* Hidden mirror — measures wrap-adjusted text height via onLayout.
-                onContentSizeChange on uncontrolled multiline TextInput is
-                unreliable on iOS Fabric (RN 0.83). Text.onLayout fires
-                reliably after every re-render that changes children. */}
-            <Text
-              aria-hidden
-              pointerEvents="none"
-              onLayout={(e) => {
-                const h = e.nativeEvent.layout.height;
-                setMeasuredHeight(Math.min(Math.max(h, minInputHeight), maxInputHeight));
-              }}
-              style={[
-                styles.textInput,
-                {
-                  lineHeight,
-                  color: 'transparent',
-                  position: 'absolute',
-                  top: 0,
-                  left: 0,
-                  right: 0,
-                },
-              ]}
-            >
-              {text.length === 0 ? ' ' : text}
-            </Text>
-            {ENABLE_PASTE_WRAPPER ? (
+            {useMirrorHeight ? (
+              /* Hidden mirror — measures wrap-adjusted text height via onLayout.
+                 onContentSizeChange on uncontrolled multiline TextInput is
+                 unreliable on iOS Fabric (RN 0.83). Text.onLayout fires
+                 reliably after every re-render that changes children. */
+              <Text
+                aria-hidden
+                pointerEvents="none"
+                onLayout={(e) => {
+                  const h = e.nativeEvent.layout.height;
+                  setMeasuredHeight(Math.min(Math.max(h, minInputHeight), maxInputHeight));
+                }}
+                style={[
+                  styles.textInput,
+                  {
+                    lineHeight,
+                    color: 'transparent',
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                  },
+                ]}
+              >
+                {text.length === 0 ? ' ' : text}
+              </Text>
+            ) : null}
+            {USE_IOS_PASTE_WRAPPER ? (
               <TextInputWrapper onPaste={onPaste}>{textField}</TextInputWrapper>
             ) : (
               textField

--- a/src/components/input/__tests__/InputBarCard.test.tsx
+++ b/src/components/input/__tests__/InputBarCard.test.tsx
@@ -12,6 +12,11 @@ jest.mock('expo-paste-input', () => ({
 
 jest.mock('expo-device', () => ({ isDevice: true }));
 
+// Default iOS enables Voice Control experiments; these tests assert mirror height behaviour.
+jest.mock('@/constants/voiceControlInputExperiments', () => ({
+  IOS_INPUT_VOICE_CONTROL_EXPERIMENTS: false,
+}));
+
 import { InputBarCard } from '../InputBarCard';
 
 const noop = () => {};

--- a/src/constants/__tests__/voiceControlInputExperiments.test.ts
+++ b/src/constants/__tests__/voiceControlInputExperiments.test.ts
@@ -1,6 +1,16 @@
-import { afterEach, describe, expect, it } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const KEY = 'EXPO_PUBLIC_IOS_INPUT_VOICE_CONTROL_EXPERIMENTS';
+
+const mockPlatformOS = jest.fn<() => 'ios' | 'android'>(() => 'ios');
+
+jest.mock('react-native', () => ({
+  Platform: {
+    get OS(): 'ios' | 'android' {
+      return mockPlatformOS();
+    },
+  },
+}));
 
 describe('IOS_INPUT_VOICE_CONTROL_EXPERIMENTS', () => {
   const original = process.env[KEY];
@@ -11,19 +21,44 @@ describe('IOS_INPUT_VOICE_CONTROL_EXPERIMENTS', () => {
     } else {
       process.env[KEY] = original;
     }
+    mockPlatformOS.mockReturnValue('ios');
     jest.resetModules();
   });
 
-  it('is false when the env var is unset', () => {
+  beforeEach(() => {
+    mockPlatformOS.mockReturnValue('ios');
+  });
+
+  it('defaults to true on iOS when the env var is unset', () => {
     delete process.env[KEY];
+    mockPlatformOS.mockReturnValue('ios');
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { IOS_INPUT_VOICE_CONTROL_EXPERIMENTS } = require('../voiceControlInputExperiments');
+    expect(IOS_INPUT_VOICE_CONTROL_EXPERIMENTS).toBe(true);
+  });
+
+  it('defaults to false on Android when the env var is unset', () => {
+    delete process.env[KEY];
+    mockPlatformOS.mockReturnValue('android');
     jest.resetModules();
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { IOS_INPUT_VOICE_CONTROL_EXPERIMENTS } = require('../voiceControlInputExperiments');
     expect(IOS_INPUT_VOICE_CONTROL_EXPERIMENTS).toBe(false);
   });
 
-  it('is true when the env var is "1"', () => {
+  it('is false on iOS when the env var is "0"', () => {
+    process.env[KEY] = '0';
+    mockPlatformOS.mockReturnValue('ios');
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { IOS_INPUT_VOICE_CONTROL_EXPERIMENTS } = require('../voiceControlInputExperiments');
+    expect(IOS_INPUT_VOICE_CONTROL_EXPERIMENTS).toBe(false);
+  });
+
+  it('is true on Android when the env var is "1"', () => {
     process.env[KEY] = '1';
+    mockPlatformOS.mockReturnValue('android');
     jest.resetModules();
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { IOS_INPUT_VOICE_CONTROL_EXPERIMENTS } = require('../voiceControlInputExperiments');

--- a/src/constants/__tests__/voiceControlInputExperiments.test.ts
+++ b/src/constants/__tests__/voiceControlInputExperiments.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+
+const KEY = 'EXPO_PUBLIC_IOS_INPUT_VOICE_CONTROL_EXPERIMENTS';
+
+describe('IOS_INPUT_VOICE_CONTROL_EXPERIMENTS', () => {
+  const original = process.env[KEY];
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[KEY];
+    } else {
+      process.env[KEY] = original;
+    }
+    jest.resetModules();
+  });
+
+  it('is false when the env var is unset', () => {
+    delete process.env[KEY];
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { IOS_INPUT_VOICE_CONTROL_EXPERIMENTS } = require('../voiceControlInputExperiments');
+    expect(IOS_INPUT_VOICE_CONTROL_EXPERIMENTS).toBe(false);
+  });
+
+  it('is true when the env var is "1"', () => {
+    process.env[KEY] = '1';
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { IOS_INPUT_VOICE_CONTROL_EXPERIMENTS } = require('../voiceControlInputExperiments');
+    expect(IOS_INPUT_VOICE_CONTROL_EXPERIMENTS).toBe(true);
+  });
+});

--- a/src/constants/voiceControlInputExperiments.ts
+++ b/src/constants/voiceControlInputExperiments.ts
@@ -1,22 +1,37 @@
+import { Platform } from 'react-native';
+
 /**
- * Opt-in **iOS Voice Control** experiments for the main chat composer (`InputBarCard`).
+ * **iOS Voice Control** / dictation-friendly layout for the main chat composer
+ * (`InputBarCard`). See RN #37991 class of bugs (multiline + native churn).
  *
- * Set at **bundle time** (Metro / EAS), then restart Metro or rebuild:
- *
- * ```bash
- * EXPO_PUBLIC_IOS_INPUT_VOICE_CONTROL_EXPERIMENTS=1 npx expo start
- * ```
- *
- * When `EXPO_PUBLIC_IOS_INPUT_VOICE_CONTROL_EXPERIMENTS=1`:
+ * When **enabled** (see below):
  *
  * 1. **Skips `expo-paste-input` `TextInputWrapper` on real iOS hardware** — same as
  *    Simulator today; inline image paste from the keyboard may not fire `onPaste`
  *    (users can still attach via the paperclip sheet).
  * 2. **Uses `minHeight` + `maxHeight` on the multiline `TextInput`** instead of the
  *    hidden mirror `Text` + fixed `height` updates — fewer native layout updates
- *    during dictation / Voice Control composition (see RN #37991 class of bugs).
+ *    during dictation / Voice Control composition.
  *
- * Defaults **off** so production and CI behaviour are unchanged.
+ * **Default:** **On** for **iOS** production and device builds (no env var required).
+ * **Android** keeps the mirror height path and unchanged paste behaviour.
+ *
+ * **Overrides** (bundle time — Metro / EAS — then restart Metro or rebuild):
+ *
+ * - `EXPO_PUBLIC_IOS_INPUT_VOICE_CONTROL_EXPERIMENTS=0` — restore legacy iOS
+ *   behaviour (paste wrapper + mirror-measured height).
+ * - `EXPO_PUBLIC_IOS_INPUT_VOICE_CONTROL_EXPERIMENTS=1` — force experiments **on**
+ *   on every platform (QA / bisection only).
  */
-export const IOS_INPUT_VOICE_CONTROL_EXPERIMENTS =
-  process.env.EXPO_PUBLIC_IOS_INPUT_VOICE_CONTROL_EXPERIMENTS === '1';
+export function resolveIosInputVoiceControlExperiments(): boolean {
+  const raw = process.env.EXPO_PUBLIC_IOS_INPUT_VOICE_CONTROL_EXPERIMENTS;
+  if (raw === '0') {
+    return false;
+  }
+  if (raw === '1') {
+    return true;
+  }
+  return Platform.OS === 'ios';
+}
+
+export const IOS_INPUT_VOICE_CONTROL_EXPERIMENTS = resolveIosInputVoiceControlExperiments();

--- a/src/constants/voiceControlInputExperiments.ts
+++ b/src/constants/voiceControlInputExperiments.ts
@@ -1,0 +1,22 @@
+/**
+ * Opt-in **iOS Voice Control** experiments for the main chat composer (`InputBarCard`).
+ *
+ * Set at **bundle time** (Metro / EAS), then restart Metro or rebuild:
+ *
+ * ```bash
+ * EXPO_PUBLIC_IOS_INPUT_VOICE_CONTROL_EXPERIMENTS=1 npx expo start
+ * ```
+ *
+ * When `EXPO_PUBLIC_IOS_INPUT_VOICE_CONTROL_EXPERIMENTS=1`:
+ *
+ * 1. **Skips `expo-paste-input` `TextInputWrapper` on real iOS hardware** — same as
+ *    Simulator today; inline image paste from the keyboard may not fire `onPaste`
+ *    (users can still attach via the paperclip sheet).
+ * 2. **Uses `minHeight` + `maxHeight` on the multiline `TextInput`** instead of the
+ *    hidden mirror `Text` + fixed `height` updates — fewer native layout updates
+ *    during dictation / Voice Control composition (see RN #37991 class of bugs).
+ *
+ * Defaults **off** so production and CI behaviour are unchanged.
+ */
+export const IOS_INPUT_VOICE_CONTROL_EXPERIMENTS =
+  process.env.EXPO_PUBLIC_IOS_INPUT_VOICE_CONTROL_EXPERIMENTS === '1';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Voice Control–friendly composer** behaviour on **iOS** without requiring env vars on device/TestFlight builds.

When **enabled** (see rules below):

1. **Skips `expo-paste-input` `TextInputWrapper` on real iOS hardware** (same as Simulator today). Inline keyboard image paste may not hit `onPaste`; paperclip flow remains.
2. **Uses `minHeight` + `maxHeight`** instead of mirror-measured fixed `height` to reduce native layout churn during dictation / Voice Control (RN #37991 class).

## Resolution rules

| Env | iOS | Android |
|-----|-----|---------|
| *(unset)* | **on** | **off** |
| `EXPO_PUBLIC_IOS_INPUT_VOICE_CONTROL_EXPERIMENTS=0` | **off** (legacy mirror + paste wrapper) | **off** |
| `=1` | **on** | **on** (QA / bisection) |

## Testing

- `src/constants/__tests__/voiceControlInputExperiments.test.ts` — env + platform matrix.
- `InputBarCard` tests mock `IOS_INPUT_VOICE_CONTROL_EXPERIMENTS: false` so mirror-height assertions stay stable.

## Follow-up

If inline image paste from the keyboard matters on iOS, consider a follow-up that restores paste-only wrapping without the layout path that hurts Voice Control.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-274977f0-e877-4d75-bbe2-c877e1ac4a4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-274977f0-e877-4d75-bbe2-c877e1ac4a4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

